### PR TITLE
Linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bower_components/
 tmp-*
+node_modules

--- a/firebase-account-menu.html
+++ b/firebase-account-menu.html
@@ -15,7 +15,7 @@
 
 <!--
 `<firebase-account-menu>` is a navigation menu to be placed inside a `<paper-toolbar>` that provides and hook the authentication functionnality of `<firebase-auth-manager>`.
-Signing up and signing in is done thanks to a self-registered `<firebase-auth-dialog>` declared somewhere else. 
+Signing up and signing in is done thanks to a self-registered `<firebase-auth-dialog>` declared somewhere else.
 It also provides access to the menu dedicated to account actions with a default logout action.
 
 Example:
@@ -91,28 +91,28 @@ Example:
       },
 
       get _firebaseAuthDialog() {
-        return this._firebaseMeta && this._firebaseMeta.byKey("authDialog");
+        return this._firebaseMeta && this._firebaseMeta.byKey('authDialog');
       },
 
       ready: function() {
-        this._firebaseMeta = new Polymer.IronMeta({type: "firebaseExtended"});
+        this._firebaseMeta = new Polymer.IronMeta({type: 'firebaseExtended'});
       },
 
       signUpButton: function() {
         if (this._firebaseAuthDialog) {
-          this._firebaseAuthDialog.setAttribute('type', "SignUp");
+          this._firebaseAuthDialog.setAttribute('type', 'SignUp');
           this._firebaseAuthDialog.open();
         } else {
-          console.warn("Missing registered firebaseAuthDialog");
+          console.warn('Missing registered firebaseAuthDialog');
         }
       },
 
       signInButton: function() {
         if (this._firebaseAuthDialog) {
-          this._firebaseAuthDialog.setAttribute('type', "SignIn");
+          this._firebaseAuthDialog.setAttribute('type', 'SignIn');
           this._firebaseAuthDialog.open();
         } else {
-          console.warn("Missing registered firebaseAuthDialog");
+          console.warn('Missing registered firebaseAuthDialog');
         }
       },
 
@@ -129,4 +129,3 @@ Example:
 
   </script>
 </dom-module>
-

--- a/firebase-auth-dialog.html
+++ b/firebase-auth-dialog.html
@@ -116,7 +116,7 @@ element.
       <content select="[introduction]" id="introduction"></content>
     </div>
 
-    <div id="provider-section" hidden="[[_computeProviderHidden(providers)]]">
+    <div id="provider-section" hidden$="[[_computeProviderHidden(providers)]]">
       <content select="[provider]" id="provider"></content>
     </div>
     <div id="providers">
@@ -361,4 +361,3 @@ element.
     }());
   </script>
 </dom-module>
-

--- a/firebase-auth-dialog.html
+++ b/firebase-auth-dialog.html
@@ -206,7 +206,7 @@ element.
            */
           type: {
             type: String,
-            observer: "_typeChanged"
+            observer: '_typeChanged'
           },
 
           /**
@@ -217,7 +217,7 @@ element.
           providers: {
             type: Array,
             value: function() { return []; },
-            observer: "_providersChanged"
+            observer: '_providersChanged'
           }
         },
 
@@ -226,7 +226,7 @@ element.
         //
         ready: function() {
           // Register the dialog in meta to be accessible from anywhere
-          new Polymer.IronMeta({type: "firebaseExtended", key: "authDialog", value: this});
+          new Polymer.IronMeta({type: 'firebaseExtended', key: 'authDialog', value: this});
         },
 
         //
@@ -252,9 +252,9 @@ element.
           } else {
             this._finishRenderClosed();
           }
-          this.$.email.value = "";
-          this.$.primary.value = "";
-          this.$.verification.value = "";
+          this.$.email.value = '';
+          this.$.primary.value = '';
+          this.$.verification.value = '';
         },
 
         _typeChanged: function() {
@@ -272,7 +272,7 @@ element.
               this.$.verification.setAttribute('hidden', '');
               break;
             default:
-              console.error("Invalid dialog type!");
+              console.error('Invalid dialog type!');
           }
         },
 
@@ -298,7 +298,7 @@ element.
             case DialogTypeValue.SIGNIN:
               return type;
             default:
-              console.error("Invalid dialog type!");
+              console.error('Invalid dialog type!');
           }
         },
 
@@ -322,7 +322,7 @@ element.
         },
 
         _handleProvider: function(e) {
-          this.fire('sign-in', { provider: e.target.getAttribute("provider") });
+          this.fire('sign-in', { provider: e.target.getAttribute('provider') });
           this.close();
         },
 
@@ -337,7 +337,7 @@ element.
               this.fire('sign-up', { params: params} );
               break;
             case DialogTypeValue.SIGNIN:
-              this.fire('sign-in', { provider: "password", params: params } );
+              this.fire('sign-in', { provider: 'password', params: params } );
               break;
           }
         }

--- a/firebase-auth-manager.html
+++ b/firebase-auth-manager.html
@@ -132,11 +132,11 @@ It also provides the update of the global variables used by `<firebase-state>`.
         window.removeEventListener('error', this._errorHandler.bind(this));
       },
 
-      _computeLoggedState: function(statusKnown,user) {
+      _computeLoggedState: function(statusKnown, user) {
         return statusKnown && !!user;
       },
 
-      _computeProfileLocation: function(location,user) {
+      _computeProfileLocation: function(location, user) {
         if (user && user.uid) {
           return [location, 'profile', user.uid].join('/');
         } else {
@@ -189,7 +189,7 @@ It also provides the update of the global variables used by `<firebase-state>`.
       },
 
       _userHandler: function(e) {
-        switch(e.type) {
+        switch (e.type) {
           case 'user-created':
             this._toastMessage = 'Sign-Up ';
             break;

--- a/firebase-auth-manager.html
+++ b/firebase-auth-manager.html
@@ -109,7 +109,7 @@ It also provides the update of the global variables used by `<firebase-state>`.
          */
         _toastMessage: {
           type: String
-        },
+        }
       },
 
       attached: function() {

--- a/firebase-auth-manager.html
+++ b/firebase-auth-manager.html
@@ -37,7 +37,7 @@ It also provides the update of the global variables used by `<firebase-state>`.
                            location="{{_profileLocation}}"
                            data="{{_profile}}"
                            on-firebase-value="_firebaseProfileLoaded">
-        </firebase-document>        
+        </firebase-document>
       </template>
 
       <firebase-error-dialog id="errorDialog"
@@ -190,17 +190,17 @@ It also provides the update of the global variables used by `<firebase-state>`.
 
       _userHandler: function(e) {
         switch(e.type) {
-          case "user-created":
-            this._toastMessage = "Sign-Up ";
+          case 'user-created':
+            this._toastMessage = 'Sign-Up ';
             break;
-          case "login":
-            this._toastMessage = "Sign-In ";
+          case 'login':
+            this._toastMessage = 'Sign-In ';
             break;
-          case "logout":
-            this._toastMessage = "Sign-Out ";
+          case 'logout':
+            this._toastMessage = 'Sign-Out ';
             break;
         }
-        this._toastMessage += "successful!";
+        this._toastMessage += 'successful!';
         this.$.toast.open();
       },
 
@@ -209,7 +209,7 @@ It also provides the update of the global variables used by `<firebase-state>`.
         if (this._lastError) {
           this.$.errorDialog.open();
         } else {
-          console.error("Unknown error: " + JSON.stringify(e));
+          console.error('Unknown error: ' + JSON.stringify(e));
         }
       }
 

--- a/firebase-auth-manager.html
+++ b/firebase-auth-manager.html
@@ -181,7 +181,7 @@ It also provides the update of the global variables used by `<firebase-state>`.
         this.$.firebaseAuth.login(e.detail.params);
       },
 
-      _signOutHandler: function(e) {
+      _signOutHandler: function() {
         this.$.firebaseAuth.logout();
         this.async(function() {
           this.set('_profile', undefined);

--- a/firebase-error-dialog.html
+++ b/firebase-error-dialog.html
@@ -117,10 +117,9 @@ element.
         } else {
           this._finishRenderClosed();
         }
-      },
+      }
 
     });
 
   </script>
 </dom-module>
-

--- a/firebase-profile-page.html
+++ b/firebase-profile-page.html
@@ -80,9 +80,9 @@ Example:
         profile: {
           type: Object,
           notify: true
-        },
+        }
 
-      },
+      }
 
     });
 

--- a/firebase-profile.html
+++ b/firebase-profile.html
@@ -58,7 +58,7 @@ Example:
         _profileLocation: {
           type: String,
           value: ''
-        },
+        }
 
       },
 

--- a/firebase-profile.html
+++ b/firebase-profile.html
@@ -63,7 +63,7 @@ Example:
       },
 
       _checkLogged: function(newLogged) {
-        if(!newLogged) {
+        if (!newLogged) {
           this.async(function() {
             this.set('profile', undefined);
           });

--- a/firebase-profile.html
+++ b/firebase-profile.html
@@ -24,7 +24,7 @@ Example:
       <firebase-document log
                          location="{{_profileLocation}}"
                          data="{{profile}}">
-      </firebase-document>      
+      </firebase-document>
     </template>
   </template>
   <script>
@@ -49,7 +49,7 @@ Example:
         _logged: {
           type: Boolean,
           value: false,
-          observer: "_checkLogged"
+          observer: '_checkLogged'
         },
 
         /**
@@ -57,7 +57,7 @@ Example:
          */
         _profileLocation: {
           type: String,
-          value: ""
+          value: ''
         },
 
       },

--- a/firebase-state.html
+++ b/firebase-state.html
@@ -7,7 +7,7 @@
 
 Example:
 
-    <firebase-state 
+    <firebase-state
       logged="{{logged}}"
       user="{{user}}">
     </firebase-profile>

--- a/firebase-state.html
+++ b/firebase-state.html
@@ -58,7 +58,7 @@ Example:
           notify: true
         }
 
-      },
+      }
 
     });
 


### PR DESCRIPTION
This addresses errors and warnings given by jslint and eslint.
Specifically
- Using $= instead of $ in one instance
- Using single quotes instead of double quotes in script sections
- Using recommended spacing
- Remove e from signOutHandler as it was not being used
- Remove additional commas
  Also attached are the remaining warnings given by jslint which are not addressed in this issue.
  These warnings are not shown when using eslint.

Regards,

John
[ErrorLogFirebaseElementExtended000.txt](https://github.com/MeTaNoV/firebase-element-extended/files/151707/ErrorLogFirebaseElementExtended000.txt)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/metanov/firebase-element-extended/13)

<!-- Reviewable:end -->
